### PR TITLE
Answer ordering and answer viewing fixes

### DIFF
--- a/Model/QuestionRepository.php
+++ b/Model/QuestionRepository.php
@@ -43,7 +43,7 @@ class QuestionRepository
     {
         $pdo = Connection::getInstance();
         $answers = array();
-        $stmt = $pdo->prepare('SELECT * FROM answer WHERE id_question = :id');
+        $stmt = $pdo->prepare('SELECT * FROM answer WHERE id_question = :id  ORDER BY publication_date DESC');
         $stmt->execute([
             'id' => $id
         ]);

--- a/View/answerList.tpl
+++ b/View/answerList.tpl
@@ -15,7 +15,7 @@
         <?php foreach($question->getAnswers() as $answer) :?>
             <div class="card fluid">
                 <div class="section">
-                    <p><?=$this->e($answer->getShortAnswer(100)) ?></p>
+                    <p><?=$this->e($answer->getAnswer(100)) ?></p>
                     <p><small>- <?=$this->e($answer->getAuthor()) ?></small></p>
                 </div>
             </div>


### PR DESCRIPTION
Nella issue #25 è stato definito di ordinare dalla risposta più recente alla meno recente. Ho applicato questa cosa anche alla view delle risposte.
Ho inoltre notato che dopo il merge del commit 1ddd2f7 (issue #24), probabilmente dovuto ad un copy-paste, nella view delle risposte ogni risposta veniva tagliata come nella home (veniva usato il testo della shortAnswer invece che quello della risposta)